### PR TITLE
ci: Add permissions for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - master
   pull_request:
 
+permissions: read-all
+
 jobs:
   test:
     name: Tests


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration file `.github/workflows/ci.yml`. The change adds a `permissions: read-all` setting to the workflow to specify the permissions granted to the workflow when it runs.